### PR TITLE
更改源

### DIFF
--- a/hass-panel-beta/config.json
+++ b/hass-panel-beta/config.json
@@ -4,7 +4,7 @@
   "slug": "hass_panel_beta",
   "description": "一个基于 React 的智能家居控制面板，此 Beta 版本仅供测试，可能问题较多，请谨慎使用",
   "url": "https://github.com/mrtian2016/hass-panel",
-  "image": "ghcr.io/mrtian2016/hass-panel",
+  "image": "ghcr.nju.edu.cn/mrtian2016/hass-panel",
   "arch": [
     "aarch64",
     "amd64",

--- a/hass-panel/config.json
+++ b/hass-panel/config.json
@@ -4,7 +4,7 @@
   "slug": "hass_panel",
   "description": "一个基于 React 的智能家居控制面板",
   "url": "https://github.com/mrtian2016/hass-panel",
-  "image": "ghcr.io/mrtian2016/hass-panel",
+  "image": "ghcr.nju.edu.cn/mrtian2016/hass-panel",
   "arch": [
     "aarch64",
     "amd64",


### PR DESCRIPTION
更改源为南京大学加速站，以解决中国用户无法下载的addon的问题