### PR TITLE
Keep one decimal place for CPU and memory usage of router card

### DIFF
--- a/frontend/src/components/RouterCard/index.js
+++ b/frontend/src/components/RouterCard/index.js
@@ -31,8 +31,8 @@ function RouterCard({ config }) {
   }, {});
 
   // 使用安全解析函数处理所有数值
-  const cpuUsage = safeParseFloat(entities.cpuUsage?.state);
-  const memoryUsage = safeParseFloat(entities.memoryUsage?.state);
+  const cpuUsage = safeParseFloat(entities.cpuUsage?.state).toFixed(1);
+  const memoryUsage = safeParseFloat(entities.memoryUsage?.state).toFixed(1);
   const wanDownloadSpeed = safeParseFloat(entities.wanDownloadSpeed?.state).toFixed(2);
   const wanUploadSpeed = safeParseFloat(entities.wanUploadSpeed?.state).toFixed(2);
   const onlineUsers = safeGetState(entities.onlineUsers);


### PR DESCRIPTION
The existing route card did not truncate the content of CPU and memory usage after the decimal point, so I made the modification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the display of system resource metrics by updating the precision for CPU and memory usage values. These figures are now consistently shown with one decimal place for a clearer and more accurate presentation, while the network speed displays remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->